### PR TITLE
feat(extract): add initial extractor with CLI + TOML config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ data/output/
 # OS / editor stuff
 .DS_Store
 .vscode/
+src/ai_chronicler/ai_chronicler.ipynb

--- a/ai_chronicler.toml
+++ b/ai_chronicler.toml
@@ -1,0 +1,5 @@
+[paths]
+input_dir = "data/input_zips"
+extracted_dir = "data/cache/extracted"
+normalised_dir = "data/cache/normalised"
+output_dir = "data/output"

--- a/src/ai_chronicler/__main__.py
+++ b/src/ai_chronicler/__main__.py
@@ -1,0 +1,4 @@
+from .cli import main
+
+if __name__ == "__main__":
+    main()

--- a/src/ai_chronicler/cli.py
+++ b/src/ai_chronicler/cli.py
@@ -1,15 +1,35 @@
 import argparse
-from extract import extract
+import tomllib
+from pathlib import Path
+
+from .extract import extract
+from .normalise import normalise
+
+def load_config(path="ai_chronicler.toml"):
+    with open(path, "rb") as f:
+        return tomllib.load(f)
 
 
 def main():
+    config = load_config()
     parser = argparse.ArgumentParser(description="Extract conversations.json from zipped ChatGPT exports")
-    parser.add_argument("src_dir", help = "Source directory for the data export .zip files")
-    parser.add_argument("out_dir", help = "Target directory to write the extracted conversations.json files")
+    parser.add_argument("--src_dir", type = Path, help = "Source directory for the data export .zip files")
+    parser.add_argument("--extr_dir", type = Path, help = "Target directory to write the extracted conversations.json files")
+    parser.add_argument("--norm_dir", type = Path, help = "Target directory to write the normalised conversations.json files")
+    parser.add_argument("--out_dir", type = Path, help = "Target directory to write the output Markdown file to")
     args = parser.parse_args()
 
-    print(f"Extracting from {args.src_dir} → {args.out_dir}")
-    extract(src_dir=args.src_dir,out_dir=args.out_dir)
+    src_dir = args.src_dir or Path(config["paths"]["input_dir"])
+    extr_dir = args.extr_dir or Path(config["paths"]["extracted_dir"])
+    norm_dir = args.norm_dir or Path(config["paths"]["normalised_dir"])
+    out_dir = args.out_dir or Path(config["paths"]["output_dir"])
+    print(f"Extracting from {src_dir} → {extr_dir}")
+    extract(src_dir=src_dir,out_dir=extr_dir)
+
+    print(f"Normalising JSON files in {extr_dir}")
+    normalise(src_dir=extr_dir,out_dir=norm_dir)
+
+   
 
 if __name__ == "__main__":
     main()

--- a/src/ai_chronicler/cli.py
+++ b/src/ai_chronicler/cli.py
@@ -1,8 +1,15 @@
-import sys
+import argparse
 from extract import extract
 
+
 def main():
-    extract(sys.argv[1],sys.argv[2])
+    parser = argparse.ArgumentParser(description="Extract conversations.json from zipped ChatGPT exports")
+    parser.add_argument("src_dir", help = "Source directory for the data export .zip files")
+    parser.add_argument("out_dir", help = "Target directory to write the extracted conversations.json files")
+    args = parser.parse_args()
+
+    print(f"Extracting from {args.src_dir} → {args.out_dir}")
+    extract(src_dir=args.src_dir,out_dir=args.out_dir)
 
 if __name__ == "__main__":
     main()

--- a/src/ai_chronicler/cli.py
+++ b/src/ai_chronicler/cli.py
@@ -1,0 +1,8 @@
+import sys
+from extract import extract
+
+def main():
+    extract(sys.argv[1],sys.argv[2])
+
+if __name__ == "__main__":
+    main()

--- a/src/ai_chronicler/extract.py
+++ b/src/ai_chronicler/extract.py
@@ -1,0 +1,21 @@
+import os
+from pathlib import Path
+import zipfile
+
+file_ext = ".zip"
+conv_file = "conversations.json"
+
+def extract(zip_dir: Path, output_dir: Path):
+    
+    for zip_file in os.listdir(zip_dir):
+
+        if zip_file.endswith(file_ext):
+            zip_file_stem = Path(zip_file).stem
+            source_file_path = os.path.join(zip_dir,zip_file)
+
+            with zipfile.ZipFile(source_file_path) as zf:
+                zf.extract(conv_file, output_dir)
+            
+            rename_source = os.path.join(output_dir,conv_file)
+            rename_target = os.path.join(output_dir,f"{zip_file_stem}_{conv_file}")
+            os.rename(rename_source,rename_target)

--- a/src/ai_chronicler/extract.py
+++ b/src/ai_chronicler/extract.py
@@ -5,17 +5,17 @@ import zipfile
 file_ext = ".zip"
 conv_file = "conversations.json"
 
-def extract(zip_dir: Path, output_dir: Path):
+def extract(src_dir: Path, out_dir: Path):
     
-    for zip_file in os.listdir(zip_dir):
+    for zip_file in os.listdir(src_dir):
 
         if zip_file.endswith(file_ext):
             zip_file_stem = Path(zip_file).stem
-            source_file_path = os.path.join(zip_dir,zip_file)
+            source_file_path = os.path.join(src_dir,zip_file)
 
             with zipfile.ZipFile(source_file_path) as zf:
-                zf.extract(conv_file, output_dir)
+                zf.extract(conv_file, out_dir)
             
-            rename_source = os.path.join(output_dir,conv_file)
-            rename_target = os.path.join(output_dir,f"{zip_file_stem}_{conv_file}")
+            rename_source = os.path.join(out_dir,conv_file)
+            rename_target = os.path.join(out_dir,f"{zip_file_stem}_{conv_file}")
             os.rename(rename_source,rename_target)

--- a/src/ai_chronicler/normalise.py
+++ b/src/ai_chronicler/normalise.py
@@ -1,0 +1,7 @@
+from pathlib import Path
+
+def normalise(src_dir: Path, out_dir: Path):
+    for path in src_dir.iterdir():
+        print(path)          # full path
+        print(path.name)     # filename
+        print(path.suffix)


### PR DESCRIPTION
### Description

This PR introduces the initial extractor stage of the pipeline, along with supporting CLI and configuration logic.

### Changes

- Added __main__.py to enable running with python -m ai_chronicler
- Added argparse CLI flags with TOML config fallback
- Introduced a pyproject.toml-style config file for paths
- Implemented extractor logic to pull conversations.json files out of exported ZIPs
- Left normalise stage as a stub for future implementation

### Why

This sets up the foundation of the processing pipeline, allowing flexible config (flags or TOML) and a clean entrypoint. It keeps scope limited to extraction for now, so later work (normalisation, deduplication, merging) can build on top.

### Next steps

- Implement normalise stage to process raw JSON files
- Add tests for extractor and CLI
- Add CI/CD config for linting & tests