### PR TITLE
feat(merge_dedupe): add merge and deduplicate feature

### DIFF
--- a/src/ai_chronicler/cli.py
+++ b/src/ai_chronicler/cli.py
@@ -4,6 +4,7 @@ from pathlib import Path
 
 from .extract import extract
 from .normalise import normalise
+from .merge_dedupe import merge_dedupe
 
 def load_config(path="ai_chronicler.toml"):
     with open(path, "rb") as f:
@@ -23,12 +24,15 @@ def main():
     extr_dir = args.extr_dir or Path(config["paths"]["extracted_dir"])
     norm_dir = args.norm_dir or Path(config["paths"]["normalised_dir"])
     out_dir = args.out_dir or Path(config["paths"]["output_dir"])
+    
     print(f"Extracting from {src_dir} → {extr_dir}")
     extract(src_dir=src_dir,out_dir=extr_dir)
 
     print(f"Normalising JSON files in {extr_dir}")
     normalise(src_dir=extr_dir,out_dir=norm_dir)
 
+    print(f"Merging and deduplication of JSON files in {norm_dir}")
+    merge_dedupe(src_dir=norm_dir,out_dir=out_dir)
    
 
 if __name__ == "__main__":

--- a/src/ai_chronicler/merge_dedupe.py
+++ b/src/ai_chronicler/merge_dedupe.py
@@ -1,0 +1,30 @@
+from pathlib import Path
+from pprint import pprint
+import json
+
+def merge_dedupe(src_dir: Path, out_dir: Path):
+    
+    master_list = []
+
+    src_dir_path = Path(src_dir)
+    for file in src_dir_path.glob("*.json"):
+        
+        with open(file, mode="r", encoding="utf-8") as file_handle:
+            json_obj = json.load(file_handle)
+            if isinstance(json_obj, list):
+                master_list.extend(json_obj)
+    
+    keys = set()
+    dedup_list = []
+    for item in master_list:
+        key = (item.get("chat_id"), item.get("msg_id"), item.get("msg_ts"))
+        if key not in keys:
+            keys.add(key)
+            dedup_list.append(item)
+
+    dedup_list.sort(key=lambda x: (x["msg_ts"] is None, x["msg_ts"]))
+
+    out_file = Path(out_dir) / "out.json"
+    with open(out_file, mode="w", encoding="utf-8") as out_file_handle:
+        json.dump(dedup_list, out_file_handle)
+


### PR DESCRIPTION
### Description

Add module to merge all normalised chat files into one, remove duplicate entries and sort chronologically, and write to output directory.

### Changes

- added `merge_dedupe.py` which takes a directory of normalised JSON files, merges them, removes duplicates, sorts, and writes out a merged file to the `output` directory.
- updated `CLI.py` to call `merge_dedupe.py`.

### Why

This stages a master JSON of the entire message history for the user, for further processing by the `splitter` and `writer` modules yet to be implemented.